### PR TITLE
integrating fireball pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 lib
+bin
 /web.config
 .idea
 build

--- a/CCBoot.js
+++ b/CCBoot.js
@@ -65,7 +65,26 @@ cc._addEventListener = function (element, type, listener, useCapture) {
 };
 
 //is nodejs ? Used to support node-webkit.
-cc._isNodeJs = typeof require !== 'undefined' && require("fs");
+cc._isNodeJs = !!(typeof process !== 'undefined' && process.versions && process.versions.node);
+
+cc.isEditor = cc._isNodeJs && typeof Editor !== 'undefined';
+
+// if global_defs not declared by uglify, declare them globally
+// (use eval to ignore uglify)
+if (typeof CC_EDITOR === 'undefined') {
+    eval('CC_EDITOR=cc.isEditor');
+}
+if (typeof CC_DEV === 'undefined') {
+    eval('CC_DEV=CC_EDITOR');
+}
+if (typeof CC_TEST === 'undefined') {
+    if (CC_EDITOR) {
+        eval('CC_TEST=typeof describe!=="undefined"');
+    }
+    else {
+        eval('CC_TEST=typeof QUnit!=="undefined"');
+    }
+}
 
 /**
  * Iterate over an object or an array, executing a function for each matched element.
@@ -1147,7 +1166,11 @@ cc.formatStr = function(){
 
 //to make sure the cc.log, cc.warn, cc.error and cc.assert would not throw error before init by debugger mode.
 
-cc.log = cc.warn = cc.error = cc.assert = function () {
+cc.log = cc.warn = cc.error = cc.assert = cc.info = function () {
+};
+
+cc._throw = function (error) {
+    cc.error(error.stack || error);
 };
 
 //+++++++++++++++++++++++++something about log end+++++++++++++++++++++++++++++
@@ -1741,7 +1764,7 @@ cc._initSys = function (config, CONFIG_KEY) {
     } catch (e) {
         var warn = function () {
             cc.warn("Warning: localStorage isn't enabled. Please confirm browser cookie or privacy option");
-        }
+        };
         sys.localStorage = {
             getItem : warn,
             setItem : warn,
@@ -1834,7 +1857,7 @@ cc._initSys = function (config, CONFIG_KEY) {
         str += "os : " + self.os + "\r\n";
         str += "platform : " + self.platform + "\r\n";
         cc.log(str);
-    }
+    };
 
     /**
      * Open a url in browser
@@ -1844,7 +1867,7 @@ cc._initSys = function (config, CONFIG_KEY) {
      */
     sys.openURL = function(url){
         window.open(url);
-    }
+    };
 };
 
 //+++++++++++++++++++++++++something about sys end+++++++++++++++++++++++++++++

--- a/CCBoot.js
+++ b/CCBoot.js
@@ -67,7 +67,7 @@ cc._addEventListener = function (element, type, listener, useCapture) {
 //is nodejs ? Used to support node-webkit.
 cc._isNodeJs = !!(typeof process !== 'undefined' && process.versions && process.versions.node);
 
-cc.isEditor = cc._isNodeJs && typeof Editor !== 'undefined';
+cc.isEditor = typeof Editor !== 'undefined';
 
 // if global_defs not declared by uglify, declare them globally
 // (use eval to ignore uglify)
@@ -2430,3 +2430,5 @@ cc._urlRegExp = new RegExp(
         "(?:/\\S*)?" +
     "$", "i"
 );
+
+require('../cocos2d/core/platform/js');

--- a/CCDebugger.js
+++ b/CCDebugger.js
@@ -293,6 +293,7 @@ cc._initDebugSetting = function (mode) {
             locLog("ERROR :  " + cc.formatStr.apply(cc, arguments));
         };
         cc.assert = function(cond, msg) {
+            'use strict';
             if (!cond && msg) {
                 for (var i = 2; i < arguments.length; i++)
                     msg = msg.replace(/(%s)|(%d)/, cc._formatString(arguments[i]));
@@ -305,16 +306,29 @@ cc._initDebugSetting = function (mode) {
             };
         }
         if(mode === ccGame.DEBUG_MODE_INFO_FOR_WEB_PAGE){
-            cc.log = function(){
+            cc.log = cc.info = function(){
                 locLog(cc.formatStr.apply(cc, arguments));
             };
         }
     } else if(console && console.log.apply){//console is null when user doesn't open dev tool on IE9
         //log to console
 
-        cc.error = function(){
-            return console.error.apply(console, arguments);
-        };
+        /**
+         * Outputs an error message to the Fireball Console (editor) or Web Console (runtime).
+         * - In Fireball, error is red.
+         * - In Chrome, error have a red icon along with red message text.
+         * @param {any|string} obj - A JavaScript string containing zero or more substitution strings.
+         * @param {any} ...subst - JavaScript objects with which to replace substitution strings within msg. This gives you additional control over the format of the output.
+         */
+        if (console.error.bind) {
+            // use bind to avoid pollute call stacks
+            cc.error = console.error.bind(console);
+        }
+        else {
+            cc.error = function(){
+                return console.error.apply(console, arguments);
+            };
+        }
         cc.assert = function (cond, msg) {
             if (!cond && msg) {
                 for (var i = 2; i < arguments.length; i++)
@@ -323,13 +337,36 @@ cc._initDebugSetting = function (mode) {
             }
         };
         if(mode !== ccGame.DEBUG_MODE_ERROR)
+            /**
+             * Outputs a warning message to the Fireball Console (editor) or Web Console (runtime).
+             * - In Fireball, warning is yellow.
+             * - In Chrome, warning have a yellow warning icon with the message text.
+             * @param {any|string} obj - A JavaScript string containing zero or more substitution strings.
+             * @param {any} ...subst - JavaScript objects with which to replace substitution strings within msg. This gives you additional control over the format of the output.
+             */
             cc.warn = function(){
                 return console.warn.apply(console, arguments);
             };
-        if(mode === ccGame.DEBUG_MODE_INFO)
-            cc.log = function(){
+        if(mode === ccGame.DEBUG_MODE_INFO) {
+            /**
+             * Outputs a message to the Fireball Console (editor) or Web Console (runtime).
+             * @param {any|string} obj - A JavaScript string containing zero or more substitution strings.
+             * @param {any} ...subst - JavaScript objects with which to replace substitution strings within msg. This gives you additional control over the format of the output.
+             */
+            cc.log = function () {
                 return console.log.apply(console, arguments);
             };
+            /**
+             * Outputs an informational message to the Fireball Console (editor) or Web Console (runtime).
+             * - In Fireball, info is blue.
+             * - In Firefox and Chrome, a small "i" icon is displayed next to these items in the Web Console's log.
+             * @param {any|string} obj - A JavaScript string containing zero or more substitution strings.
+             * @param {any} ...subst - JavaScript objects with which to replace substitution strings within msg. This gives you additional control over the format of the output.
+             */
+            cc.info = function () {
+                (console.info || console.log).apply(console, arguments);
+            };
+        }
     }
 };
 cc._initDebugSetting(cc.game.config[cc.game.CONFIG_KEY.debugMode]);

--- a/cocos2d/compression/zlib.min.js
+++ b/cocos2d/compression/zlib.min.js
@@ -49,7 +49,7 @@ var sb=[0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13];H&&
 var _p = window;
 _p = _p.Zlib = _p["Zlib"];
 _p.Deflate = _p["Deflate"];
-_p.Deflate.compress =_p.Deflate["compress"];
+_p.Deflate.compress = _p.Deflate["compress"];
 _p.Inflate = _p["Inflate"];
 _p.Inflate.BufferType = _p.Inflate["BufferType"];
 _p.Inflate.prototype.decompress = _p.Inflate.prototype["decompress"];

--- a/cocos2d/core/labelttf/CCLabelTTFCanvasRenderCmd.js
+++ b/cocos2d/core/labelttf/CCLabelTTFCanvasRenderCmd.js
@@ -389,7 +389,7 @@ cc.LabelTTF._firsrEnglish = /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]/;
     };
 
     cc.LabelTTF.CacheRenderCmd.prototype = Object.create( cc.LabelTTF.RenderCmd.prototype);
-    cc.inject(cc.LabelTTF.RenderCmd.prototype, cc.LabelTTF.CacheRenderCmd.prototype);
+    cc.js.mixin(cc.LabelTTF.RenderCmd.prototype, cc.LabelTTF.CacheRenderCmd.prototype);
 
     var proto = cc.LabelTTF.CacheRenderCmd.prototype;
     proto.constructor = cc.LabelTTF.CacheRenderCmd;
@@ -448,7 +448,7 @@ cc.LabelTTF._firsrEnglish = /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]/;
     };
 
     var proto = cc.LabelTTF.CacheCanvasRenderCmd.prototype = Object.create(cc.Sprite.CanvasRenderCmd.prototype);
-    cc.inject(cc.LabelTTF.CacheRenderCmd.prototype, proto);
+    cc.js.mixin(cc.LabelTTF.CacheRenderCmd.prototype, proto);
     proto.constructor = cc.LabelTTF.CacheCanvasRenderCmd;
 })();
 
@@ -459,7 +459,7 @@ cc.LabelTTF._firsrEnglish = /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]/;
     };
 
     cc.LabelTTF.CanvasRenderCmd.prototype = Object.create(cc.Sprite.CanvasRenderCmd.prototype);
-    cc.inject(cc.LabelTTF.RenderCmd.prototype, cc.LabelTTF.CanvasRenderCmd.prototype);
+    cc.js.mixin(cc.LabelTTF.RenderCmd.prototype, cc.LabelTTF.CanvasRenderCmd.prototype);
 
     var proto = cc.LabelTTF.CanvasRenderCmd.prototype;
     proto.constructor = cc.LabelTTF.CanvasRenderCmd;

--- a/cocos2d/core/labelttf/CCLabelTTFWebGLRenderCmd.js
+++ b/cocos2d/core/labelttf/CCLabelTTFWebGLRenderCmd.js
@@ -30,6 +30,6 @@
         this.setShaderProgram(cc.shaderCache.programForKey(cc.LabelTTF._SHADER_PROGRAM));
     };
     var proto = cc.LabelTTF.WebGLRenderCmd.prototype = Object.create(cc.Sprite.WebGLRenderCmd.prototype);
-    cc.inject(cc.LabelTTF.CacheRenderCmd.prototype, proto);
+    cc.js.mixin(cc.LabelTTF.CacheRenderCmd.prototype, proto);
     proto.constructor = cc.LabelTTF.WebGLRenderCmd;
 })();

--- a/cocos2d/core/layers/CCLayerCanvasRenderCmd.js
+++ b/cocos2d/core/layers/CCLayerCanvasRenderCmd.js
@@ -368,7 +368,7 @@
         this._endStopStr = null;
     };
     var proto = cc.LayerGradient.CanvasRenderCmd.prototype = Object.create(cc.LayerColor.CanvasRenderCmd.prototype);
-    cc.inject(cc.LayerGradient.RenderCmd, proto);
+    cc.js.mixin(cc.LayerGradient.RenderCmd, proto);
     proto.constructor = cc.LayerGradient.CanvasRenderCmd;
 
     proto.rendering = function (ctx, scaleX, scaleY) {

--- a/cocos2d/core/layers/CCLayerWebGLRenderCmd.js
+++ b/cocos2d/core/layers/CCLayerWebGLRenderCmd.js
@@ -164,7 +164,7 @@
         this._clippingRectDirty = false;
     };
     var proto = cc.LayerGradient.WebGLRenderCmd.prototype = Object.create(cc.LayerColor.WebGLRenderCmd.prototype);
-    cc.inject(cc.LayerGradient.RenderCmd, proto);
+    cc.js.mixin(cc.LayerGradient.RenderCmd, proto);
     proto.constructor = cc.LayerGradient.WebGLRenderCmd;
 
     proto._syncStatus = function (parentCmd) {

--- a/cocos2d/core/platform/CCClass.js
+++ b/cocos2d/core/platform/CCClass.js
@@ -325,9 +325,3 @@ cc.clone = function (obj) {
     }
     return newObj;
 };
-
-cc.inject = function(srcPrototype, destPrototype){
-    for(var key in srcPrototype)
-        destPrototype[key] = srcPrototype[key];
-};
-

--- a/cocos2d/core/platform/JS.js
+++ b/cocos2d/core/platform/JS.js
@@ -1,0 +1,529 @@
+
+function _getPropertyDescriptor (obj, name) {
+    var pd = Object.getOwnPropertyDescriptor(obj, name);
+    if (pd) {
+        return pd;
+    }
+    var p = Object.getPrototypeOf(obj);
+    if (p) {
+        return _getPropertyDescriptor(p, name);
+    }
+    else {
+        return null;
+    }
+}
+
+function _copyprop(name, source, target) {
+    var pd = _getPropertyDescriptor(source, name);
+    Object.defineProperty(target, name, pd);
+}
+
+/**
+ * This module provides some JavaScript utilities.
+ *
+ * @module cc.JS
+ */
+var JS = {
+
+    /**
+     * copy all properties not defined in obj from arguments[1...n]
+     * @method addon
+     * @param {object} obj object to extend its properties
+     * @param {object} ...sourceObj source object to copy properties from
+     * @return {object} the result obj
+     */
+    addon: function (obj) {
+        'use strict';
+        obj = obj || {};
+        for (var i = 1, length = arguments.length; i < length; i++) {
+            var source = arguments[i];
+            if (source) {
+                if (typeof source !== 'object') {
+                    cc.error('cc.JS.addon called on non-object:', source);
+                    continue;
+                }
+                for ( var name in source) {
+                    if ( !(name in obj) ) {
+                        _copyprop( name, source, obj);
+                    }
+                }
+            }
+        }
+        return obj;
+    },
+
+    /**
+     * copy all properties from arguments[1...n] to obj
+     * @method mixin
+     * @param {object} obj
+     * @param {object} ...sourceObj
+     * @return {object} the result obj
+     */
+    mixin: function (obj) {
+        'use strict';
+        obj = obj || {};
+        for (var i = 1, length = arguments.length; i < length; i++) {
+            var source = arguments[i];
+            if (source) {
+                if (typeof source !== 'object') {
+                    cc.error('cc.JS.mixin: arguments must be type object:', source);
+                    continue;
+                }
+                for ( var name in source) {
+                    _copyprop( name, source, obj);
+                }
+            }
+        }
+        return obj;
+    },
+
+    /**
+     * Derive the class from the supplied base class.
+     * Both classes are just native javascript constructors, not created by cc.FireClass, so
+     * usually you will want to inherit using {% crosslink cc.FireClass cc.FireClass %} instead.
+     *
+     * @method extend
+     * @param {function} cls
+     * @param {function} base - the baseclass to inherit
+     * @return {function} the result class
+     */
+    extend: function (cls, base) {
+        if (CC_DEV) {
+            if (!base) {
+                cc.error('The base class to extend from must be non-nil');
+                return;
+            }
+            if (!cls) {
+                cc.error('The class to extend must be non-nil');
+                return;
+            }
+        }
+        for (var p in base) if (base.hasOwnProperty(p)) cls[p] = base[p];
+        function __() { this.constructor = cls; }
+        __.prototype = base.prototype;
+        cls.prototype = new __();
+        return cls;
+    },
+
+    /**
+     * Removes all enumerable properties from object
+     * @method clear
+     * @param {any} obj
+     */
+    clear: function (obj) {
+        var keys = Object.keys(obj);
+        for (var i = 0; i < keys.length; i++) {
+            delete obj[keys[i]];
+        }
+    },
+
+    /**
+     * 查找所有父类，直到找到原始定义 property 的地方
+     * @method getPropertyDescriptor
+     * @param {object} obj
+     * @param {string} name
+     * @return {object}
+     */
+    getPropertyDescriptor: _getPropertyDescriptor
+};
+
+/**
+ * Get class name of the object, if object is just a {} (and which class named 'Object'), it will return null.
+ * (modified from <a href="http://stackoverflow.com/questions/1249531/how-to-get-a-javascript-objects-class">the code from this stackoverflow post</a>)
+ * @method getClassName
+ * @param {object|function} obj - instance or constructor
+ * @return {string}
+ */
+JS.getClassName = function (obj) {
+    if (typeof obj === 'function') {
+        if (obj.prototype.__classname__) {
+            return obj.prototype.__classname__;
+        }
+    }
+    else if (obj && obj.constructor) {
+        if (obj.constructor.prototype && obj.constructor.prototype.hasOwnProperty('__classname__')) {
+            return obj.__classname__;
+        }
+        var retval;
+        //  for browsers which have name property in the constructor of the object, such as chrome
+        if (obj.constructor.name) {
+            retval = obj.constructor.name;
+        }
+        if (obj.constructor.toString) {
+            var arr, str = obj.constructor.toString();
+            if (str.charAt(0) === '[') {
+                // str is "[object objectClass]"
+                arr = str.match(/\[\w+\s*(\w+)\]/);
+            }
+            else {
+                // str is function objectClass () {} for IE Firefox
+                arr = str.match(/function\s*(\w+)/);
+            }
+            if (arr && arr.length === 2) {
+                retval = arr[1];
+            }
+        }
+        return retval !== 'Object' ? retval : '';
+    }
+    return '';
+};
+
+var TCID = 'cc.TmpCId.';
+
+function getTempClassIdInEditor () {
+    if (CC_EDITOR) {
+        return TCID + Editor.uuid();
+    }
+}
+
+JS._isTempClassId = function (id) {
+    return CC_EDITOR && id.startsWith(TCID);
+};
+
+// id 注册
+(function () {
+    var _idToClass = {};
+    var _nameToClass = {};
+
+    function getRegister (key, table) {
+        return function (id, constructor) {
+            // deregister old
+            if (constructor.prototype.hasOwnProperty(key)) {
+                delete table[constructor.prototype[key]];
+            }
+            constructor.prototype[key] = id;
+            // register class
+            if (id) {
+                var registered = table[id];
+                if (registered && registered !== constructor) {
+                    var error = 'A Class already exists with the same ' + key + ' : "' + id + '".';
+                    if (CC_TEST) {
+                        error += ' (This may be caused by error of unit test.) \
+If you dont need serialization, you can set class id to "". You can also call \
+cc.JS.unregisterClass to remove the id of unused class';
+                    }
+                    cc.error(error);
+                }
+                else {
+                    table[id] = constructor;
+                }
+                //if (id === "") {
+                //    console.trace("", table === _nameToClass);
+                //}
+            }
+        };
+    }
+
+    /**
+     * Register the class by specified id, if its classname is not defined, the class name will also be set.
+     * @method _setClassId
+     * @param {string} classId
+     * @param {function} constructor
+     * @private
+     */
+    JS._setClassId = getRegister('__cid__', _idToClass);
+
+    var doSetClassName = getRegister('__classname__', _nameToClass);
+
+    /**
+     * Register the class by specified name manually
+     * @method setClassName
+     * @param {string} className
+     * @param {function} constructor
+     */
+    JS.setClassName = function (className, constructor) {
+        doSetClassName(className, constructor);
+        // auto set class id
+        if (!constructor.prototype.hasOwnProperty('__cid__')) {
+            var id = className || (CC_EDITOR && getTempClassIdInEditor());
+            if (id) {
+                JS._setClassId(id, constructor);
+            }
+        }
+    };
+
+    /**
+     * Unregister a class from fireball.
+     *
+     * If you dont need a registered class anymore, you should unregister the class so that Fireball will not keep its reference anymore.
+     * Please note that its still your responsibility to free other references to the class.
+     *
+     * @method unregisterClass
+     * @param {function} ...constructor - the class you will want to unregister, any number of classes can be added
+     */
+    JS.unregisterClass = function (constructor) {
+        'use strict';
+        for (var i = 0; i < arguments.length; i++) {
+            var p = arguments[i].prototype;
+            var classId = p.__cid__;
+            if (classId) {
+                delete _idToClass[classId];
+            }
+            var classname = p.__classname__;
+            if (classname) {
+                delete _nameToClass[classname];
+            }
+        }
+    };
+
+    /**
+     * Get the registered class by id
+     * @method _getClassById
+     * @param {string} classId
+     * @return {function} constructor
+     * @private
+     */
+    JS._getClassById = function (classId) {
+        var cls = _idToClass[classId];
+        if (CC_EDITOR && !cls) {
+            if (classId.length === 32) {
+                // 尝试解析旧的 uuid 压缩格式
+                cls = _idToClass[Editor.compressUuid(classId)];
+            }
+        }
+        return cls;
+    };
+
+    /**
+     * Get the registered class by name
+     * @method getClassByName
+     * @param {string} classname
+     * @return {function} constructor
+     */
+    JS.getClassByName = function (classname) {
+        return _nameToClass[classname];
+    };
+
+    /**
+     * Get class id of the object
+     * @method _getClassId
+     * @param {object|function} obj - instance or constructor
+     * @param {boolean} [allowTempId=true] - can return temp id in editor
+     * @return {string}
+     * @private
+     */
+    JS._getClassId = function (obj, allowTempId) {
+        allowTempId = (typeof allowTempId !== 'undefined' ? allowTempId: true) && CC_EDITOR;
+
+        var res;
+        if (typeof obj === 'function' && obj.prototype.hasOwnProperty('__cid__')) {
+            res = obj.prototype.__cid__;
+            if (!allowTempId && JS._isTempClassId(res)) {
+                return '';
+            }
+            return res;
+        }
+        if (obj && obj.constructor) {
+            var prototype = obj.constructor.prototype;
+            if (prototype && prototype.hasOwnProperty('__cid__')) {
+                res = obj.__cid__;
+                if (!allowTempId && JS._isTempClassId(res)) {
+                    return '';
+                }
+                return res;
+            }
+        }
+        return '';
+    };
+
+    if (CC_EDITOR) {
+        Object.defineProperty(JS, '_registeredClassIds', {
+            get: function () {
+                var dump = {};
+                for (var id in _idToClass) {
+                    dump[id] = _idToClass[id];
+                }
+                return dump;
+            },
+            set: function (value) {
+                JS.clear(_idToClass);
+                for (var id in value) {
+                    _idToClass[id] = value[id];
+                }
+            }
+        });
+        Object.defineProperty(JS, '_registeredClassNames', {
+            get: function () {
+                var dump = {};
+                for (var id in _nameToClass) {
+                    dump[id] = _nameToClass[id];
+                }
+                return dump;
+            },
+            set: function (value) {
+                JS.clear(_nameToClass);
+                for (var id in value) {
+                    _nameToClass[id] = value[id];
+                }
+            }
+        });
+    }
+
+})();
+
+/**
+ * Define get set accessor, just help to call Object.defineProperty(...)
+ * @method getset
+ * @param {any} obj
+ * @param {string} prop
+ * @param {function} getter
+ * @param {function} setter
+ * @param {Boolean} [enumerable=false]
+ */
+JS.getset = function (obj, prop, getter, setter, enumerable) {
+    Object.defineProperty(obj, prop, {
+        get: getter,
+        set: setter,
+        enumerable: !!enumerable
+    });
+};
+
+/**
+ * Define get accessor, just help to call Object.defineProperty(...)
+ * @method get
+ * @param {any} obj
+ * @param {string} prop
+ * @param {function} getter
+ * @param {Boolean} [enumerable=false]
+ */
+JS.get = function (obj, prop, getter, enumerable) {
+    Object.defineProperty(obj, prop, {
+        get: getter,
+        enumerable: !!enumerable
+    });
+};
+
+/**
+ * Define set accessor, just help to call Object.defineProperty(...)
+ * @method set
+ * @param {any} obj
+ * @param {string} prop
+ * @param {function} setter
+ * @param {Boolean} [enumerable=false]
+ */
+JS.set = function (obj, prop, setter, enumerable) {
+    Object.defineProperty(obj, prop, {
+        set: setter,
+        enumerable: !!enumerable
+    });
+};
+
+/**
+ * Defines a polyfill field for obsoleted codes.
+ * @method obsolete
+ * @param {any} obj - YourObject or YourClass.prototype
+ * @param {string} obsoleted - "OldParam" or "YourClass.OldParam"
+ * @param {string} newPropName - "NewParam"
+ * @param {bool} [writable=false]
+ */
+JS.obsolete = function (obj, obsoleted, newPropName, writable) {
+    var oldName = obsoleted.split('.').slice(-1);
+    JS.get(obj, oldName, function () {
+        if (CC_DEV) {
+            cc.warn('"%s" is deprecated, use "%s" instead please.', obsoleted, newPropName);
+        }
+        return obj[newPropName];
+    });
+    if (writable) {
+        JS.set(obj, oldName, function (value) {
+            if (CC_DEV) {
+                cc.warn('"%s" is deprecated, use "%s" instead please.', obsoleted, newPropName);
+            }
+            obj[newPropName] = value;
+        });
+    }
+};
+
+/**
+ * Defines all polyfill fields for obsoleted codes corresponding to the enumerable properties of props.
+ * @method obsoletes
+ * @param {any} obj - YourObject or YourClass.prototype
+ * @param {any} objName - "YourObject" or "YourClass"
+ * @param {object} props
+ * @param {bool} [writable=false]
+ */
+JS.obsoletes = function (obj, objName, props, writable) {
+    for (var obsoleted in props) {
+        var newName = props[obsoleted];
+        JS.obsolete(obj, objName + '.' + obsoleted, newName, writable);
+    }
+};
+
+/**
+ * @class Array
+ * @static
+ */
+JS.Array = {
+    /**
+     * Removes the first occurrence of a specific object from the array.
+     * @method remove
+     * @param {any[]} array
+     * @param {any} value
+     * @return {Boolean}
+     */
+    remove: function (array, value) {
+        var index = array.indexOf(value);
+        if (index !== -1) {
+            array.splice(index, 1);
+            return true;
+        }
+        else {
+            return false;
+        }
+    },
+
+    /**
+     * Removes the array item at the specified index.
+     * @method removeAt
+     * @param {any[]} array
+     * @param {number} index
+     */
+    removeAt: function (array, index) {
+        array.splice(index, 1);
+    },
+
+    /**
+     * Determines whether the array contains a specific value.
+     * @method contains
+     * @param {any[]} array
+     * @param {any} value
+     * @return {Boolean}
+     */
+    contains: function (array, value) {
+        return array.indexOf(value) !== -1;
+    }
+};
+
+/**
+ * @class String
+ * @static
+ */
+JS.String = {
+    /**
+     * The startsWith() method determines whether a string begins with the characters of another string, returning true or false as appropriate.
+     * @method startsWith
+     * @param {string} string
+     * @param {string} searchString - The characters to be searched for at the start of this string.
+     * @param {string} [position=0] - Optional. The position in this string at which to begin searching for searchString; defaults to 0.
+     * @return {boolean}
+     */
+    startsWith: function (string, searchString, position) {
+        return string.startsWith(searchString, position);
+    },
+
+    /**
+     * This method lets you determine whether or not a string ends with another string.
+     * @method startsWith
+     * @param {string} string
+     * @param {string} searchString - The characters to be searched for at the end of this string.
+     * @param {string} [position=0] - Optional. Search within this string as if this string were only this long; defaults to this string's actual length, clamped within the range established by this string's length.
+     * @return {boolean}
+     */
+    endsWith: function (string, searchString, position) {
+        return string.endsWith(searchString, position);
+    },
+};
+
+cc.JS = JS;
+
+module.exports = JS;

--- a/cocos2d/core/platform/js.js
+++ b/cocos2d/core/platform/js.js
@@ -21,9 +21,9 @@ function _copyprop(name, source, target) {
 /**
  * This module provides some JavaScript utilities.
  *
- * @module cc.JS
+ * @module cc.js
  */
-var JS = {
+var js = {
 
     /**
      * copy all properties not defined in obj from arguments[1...n]
@@ -39,7 +39,7 @@ var JS = {
             var source = arguments[i];
             if (source) {
                 if (typeof source !== 'object') {
-                    cc.error('cc.JS.addon called on non-object:', source);
+                    cc.error('cc.js.addon called on non-object:', source);
                     continue;
                 }
                 for ( var name in source) {
@@ -66,7 +66,7 @@ var JS = {
             var source = arguments[i];
             if (source) {
                 if (typeof source !== 'object') {
-                    cc.error('cc.JS.mixin: arguments must be type object:', source);
+                    cc.error('cc.js.mixin: arguments must be type object:', source);
                     continue;
                 }
                 for ( var name in source) {
@@ -118,7 +118,7 @@ var JS = {
     },
 
     /**
-     * 查找所有父类，直到找到原始定义 property 的地方
+     * Get property descriptor in object and all its ancestors
      * @method getPropertyDescriptor
      * @param {object} obj
      * @param {string} name
@@ -134,7 +134,7 @@ var JS = {
  * @param {object|function} obj - instance or constructor
  * @return {string}
  */
-JS.getClassName = function (obj) {
+js.getClassName = function (obj) {
     if (typeof obj === 'function') {
         if (obj.prototype.__classname__) {
             return obj.prototype.__classname__;
@@ -176,7 +176,7 @@ function getTempClassIdInEditor () {
     }
 }
 
-JS._isTempClassId = function (id) {
+js._isTempClassId = function (id) {
     return CC_EDITOR && id.startsWith(TCID);
 };
 
@@ -200,7 +200,7 @@ JS._isTempClassId = function (id) {
                     if (CC_TEST) {
                         error += ' (This may be caused by error of unit test.) \
 If you dont need serialization, you can set class id to "". You can also call \
-cc.JS.unregisterClass to remove the id of unused class';
+cc.js.unregisterClass to remove the id of unused class';
                     }
                     cc.error(error);
                 }
@@ -221,7 +221,7 @@ cc.JS.unregisterClass to remove the id of unused class';
      * @param {function} constructor
      * @private
      */
-    JS._setClassId = getRegister('__cid__', _idToClass);
+    js._setClassId = getRegister('__cid__', _idToClass);
 
     var doSetClassName = getRegister('__classname__', _nameToClass);
 
@@ -231,13 +231,13 @@ cc.JS.unregisterClass to remove the id of unused class';
      * @param {string} className
      * @param {function} constructor
      */
-    JS.setClassName = function (className, constructor) {
+    js.setClassName = function (className, constructor) {
         doSetClassName(className, constructor);
         // auto set class id
         if (!constructor.prototype.hasOwnProperty('__cid__')) {
             var id = className || (CC_EDITOR && getTempClassIdInEditor());
             if (id) {
-                JS._setClassId(id, constructor);
+                js._setClassId(id, constructor);
             }
         }
     };
@@ -251,7 +251,7 @@ cc.JS.unregisterClass to remove the id of unused class';
      * @method unregisterClass
      * @param {function} ...constructor - the class you will want to unregister, any number of classes can be added
      */
-    JS.unregisterClass = function (constructor) {
+    js.unregisterClass = function (constructor) {
         'use strict';
         for (var i = 0; i < arguments.length; i++) {
             var p = arguments[i].prototype;
@@ -273,15 +273,8 @@ cc.JS.unregisterClass to remove the id of unused class';
      * @return {function} constructor
      * @private
      */
-    JS._getClassById = function (classId) {
-        var cls = _idToClass[classId];
-        if (CC_EDITOR && !cls) {
-            if (classId.length === 32) {
-                // 尝试解析旧的 uuid 压缩格式
-                cls = _idToClass[Editor.compressUuid(classId)];
-            }
-        }
-        return cls;
+    js._getClassById = function (classId) {
+        return _idToClass[classId];
     };
 
     /**
@@ -290,7 +283,7 @@ cc.JS.unregisterClass to remove the id of unused class';
      * @param {string} classname
      * @return {function} constructor
      */
-    JS.getClassByName = function (classname) {
+    js.getClassByName = function (classname) {
         return _nameToClass[classname];
     };
 
@@ -302,13 +295,13 @@ cc.JS.unregisterClass to remove the id of unused class';
      * @return {string}
      * @private
      */
-    JS._getClassId = function (obj, allowTempId) {
+    js._getClassId = function (obj, allowTempId) {
         allowTempId = (typeof allowTempId !== 'undefined' ? allowTempId: true) && CC_EDITOR;
 
         var res;
         if (typeof obj === 'function' && obj.prototype.hasOwnProperty('__cid__')) {
             res = obj.prototype.__cid__;
-            if (!allowTempId && JS._isTempClassId(res)) {
+            if (!allowTempId && js._isTempClassId(res)) {
                 return '';
             }
             return res;
@@ -317,7 +310,7 @@ cc.JS.unregisterClass to remove the id of unused class';
             var prototype = obj.constructor.prototype;
             if (prototype && prototype.hasOwnProperty('__cid__')) {
                 res = obj.__cid__;
-                if (!allowTempId && JS._isTempClassId(res)) {
+                if (!allowTempId && js._isTempClassId(res)) {
                     return '';
                 }
                 return res;
@@ -327,7 +320,7 @@ cc.JS.unregisterClass to remove the id of unused class';
     };
 
     if (CC_EDITOR) {
-        Object.defineProperty(JS, '_registeredClassIds', {
+        Object.defineProperty(js, '_registeredClassIds', {
             get: function () {
                 var dump = {};
                 for (var id in _idToClass) {
@@ -336,13 +329,13 @@ cc.JS.unregisterClass to remove the id of unused class';
                 return dump;
             },
             set: function (value) {
-                JS.clear(_idToClass);
+                js.clear(_idToClass);
                 for (var id in value) {
                     _idToClass[id] = value[id];
                 }
             }
         });
-        Object.defineProperty(JS, '_registeredClassNames', {
+        Object.defineProperty(js, '_registeredClassNames', {
             get: function () {
                 var dump = {};
                 for (var id in _nameToClass) {
@@ -351,7 +344,7 @@ cc.JS.unregisterClass to remove the id of unused class';
                 return dump;
             },
             set: function (value) {
-                JS.clear(_nameToClass);
+                js.clear(_nameToClass);
                 for (var id in value) {
                     _nameToClass[id] = value[id];
                 }
@@ -370,7 +363,7 @@ cc.JS.unregisterClass to remove the id of unused class';
  * @param {function} setter
  * @param {Boolean} [enumerable=false]
  */
-JS.getset = function (obj, prop, getter, setter, enumerable) {
+js.getset = function (obj, prop, getter, setter, enumerable) {
     Object.defineProperty(obj, prop, {
         get: getter,
         set: setter,
@@ -386,7 +379,7 @@ JS.getset = function (obj, prop, getter, setter, enumerable) {
  * @param {function} getter
  * @param {Boolean} [enumerable=false]
  */
-JS.get = function (obj, prop, getter, enumerable) {
+js.get = function (obj, prop, getter, enumerable) {
     Object.defineProperty(obj, prop, {
         get: getter,
         enumerable: !!enumerable
@@ -401,7 +394,7 @@ JS.get = function (obj, prop, getter, enumerable) {
  * @param {function} setter
  * @param {Boolean} [enumerable=false]
  */
-JS.set = function (obj, prop, setter, enumerable) {
+js.set = function (obj, prop, setter, enumerable) {
     Object.defineProperty(obj, prop, {
         set: setter,
         enumerable: !!enumerable
@@ -416,16 +409,16 @@ JS.set = function (obj, prop, setter, enumerable) {
  * @param {string} newPropName - "NewParam"
  * @param {bool} [writable=false]
  */
-JS.obsolete = function (obj, obsoleted, newPropName, writable) {
+js.obsolete = function (obj, obsoleted, newPropName, writable) {
     var oldName = obsoleted.split('.').slice(-1);
-    JS.get(obj, oldName, function () {
+    js.get(obj, oldName, function () {
         if (CC_DEV) {
             cc.warn('"%s" is deprecated, use "%s" instead please.', obsoleted, newPropName);
         }
         return obj[newPropName];
     });
     if (writable) {
-        JS.set(obj, oldName, function (value) {
+        js.set(obj, oldName, function (value) {
             if (CC_DEV) {
                 cc.warn('"%s" is deprecated, use "%s" instead please.', obsoleted, newPropName);
             }
@@ -442,10 +435,10 @@ JS.obsolete = function (obj, obsoleted, newPropName, writable) {
  * @param {object} props
  * @param {bool} [writable=false]
  */
-JS.obsoletes = function (obj, objName, props, writable) {
+js.obsoletes = function (obj, objName, props, writable) {
     for (var obsoleted in props) {
         var newName = props[obsoleted];
-        JS.obsolete(obj, objName + '.' + obsoleted, newName, writable);
+        js.obsolete(obj, objName + '.' + obsoleted, newName, writable);
     }
 };
 
@@ -453,7 +446,7 @@ JS.obsoletes = function (obj, objName, props, writable) {
  * @class Array
  * @static
  */
-JS.Array = {
+js.Array = {
     /**
      * Removes the first occurrence of a specific object from the array.
      * @method remove
@@ -494,36 +487,6 @@ JS.Array = {
     }
 };
 
-/**
- * @class String
- * @static
- */
-JS.String = {
-    /**
-     * The startsWith() method determines whether a string begins with the characters of another string, returning true or false as appropriate.
-     * @method startsWith
-     * @param {string} string
-     * @param {string} searchString - The characters to be searched for at the start of this string.
-     * @param {string} [position=0] - Optional. The position in this string at which to begin searching for searchString; defaults to 0.
-     * @return {boolean}
-     */
-    startsWith: function (string, searchString, position) {
-        return string.startsWith(searchString, position);
-    },
+cc.js = js;
 
-    /**
-     * This method lets you determine whether or not a string ends with another string.
-     * @method startsWith
-     * @param {string} string
-     * @param {string} searchString - The characters to be searched for at the end of this string.
-     * @param {string} [position=0] - Optional. Search within this string as if this string were only this long; defaults to this string's actual length, clamped within the range established by this string's length.
-     * @return {boolean}
-     */
-    endsWith: function (string, searchString, position) {
-        return string.endsWith(searchString, position);
-    },
-};
-
-cc.JS = JS;
-
-module.exports = JS;
+module.exports = js;

--- a/cocos2d/deprecated.js
+++ b/cocos2d/deprecated.js
@@ -1,0 +1,8 @@
+var js = cc.js;
+
+var INFO = '"%s" is deprecated, use "%s" instead please.';
+
+js.get(cc, "inject", function () {
+    cc.warn(INFO, 'cc.inject', 'cc.js.mixin');
+    return js.mixin;
+});

--- a/editor/static/cc-config.js
+++ b/editor/static/cc-config.js
@@ -1,0 +1,4 @@
+document.ccConfig = {
+    'debugMode' : 1,
+    "renderMode": 0                 // 0: auto, 1: Canvas, 2: WebGL
+};

--- a/editor/static/cc-config.min.js
+++ b/editor/static/cc-config.min.js
@@ -1,0 +1,3 @@
+document.ccConfig = {
+    "renderMode": 0                 // 0: auto, 1: Canvas, 2: WebGL
+};

--- a/extensions/ccui/base-classes/CCProtectedNodeCanvasRenderCmd.js
+++ b/extensions/ccui/base-classes/CCProtectedNodeCanvasRenderCmd.js
@@ -145,7 +145,7 @@
     };
 
     var proto = cc.ProtectedNode.CanvasRenderCmd.prototype = Object.create(cc.Node.CanvasRenderCmd.prototype);
-    cc.inject(cc.ProtectedNode.RenderCmd, proto);
+    cc.js.mixin(cc.ProtectedNode.RenderCmd, proto);
     proto.constructor = cc.ProtectedNode.CanvasRenderCmd;
 
     proto.visit = function(parentCmd){

--- a/extensions/ccui/base-classes/CCProtectedNodeWebGLRenderCmd.js
+++ b/extensions/ccui/base-classes/CCProtectedNodeWebGLRenderCmd.js
@@ -30,7 +30,7 @@
     };
 
     var proto = cc.ProtectedNode.WebGLRenderCmd.prototype = Object.create(cc.Node.WebGLRenderCmd.prototype);
-    cc.inject(cc.ProtectedNode.RenderCmd, proto);
+    cc.js.mixin(cc.ProtectedNode.RenderCmd, proto);
     proto.constructor = cc.ProtectedNode.WebGLRenderCmd;
 
     proto.visit = function(parentCmd){

--- a/extensions/cocostudio/armature/CCArmatureCanvasRenderCmd.js
+++ b/extensions/cocostudio/armature/CCArmatureCanvasRenderCmd.js
@@ -52,7 +52,7 @@
     };
 
     var proto = ccs.Armature.CanvasRenderCmd.prototype = Object.create(cc.Node.CanvasRenderCmd.prototype);
-    cc.inject(ccs.Armature.RenderCmd, proto);
+    cc.js.mixin(ccs.Armature.RenderCmd, proto);
     proto.constructor = ccs.Armature.CanvasRenderCmd;
 
     proto._startCmdCallback = function(ctx, scaleX, scaleY){

--- a/extensions/cocostudio/armature/CCArmatureWebGLRenderCmd.js
+++ b/extensions/cocostudio/armature/CCArmatureWebGLRenderCmd.js
@@ -32,7 +32,7 @@
     };
 
     var proto = ccs.Armature.WebGLRenderCmd.prototype = Object.create(cc.Node.WebGLRenderCmd.prototype);
-    cc.inject(ccs.Armature.RenderCmd, proto);
+    cc.js.mixin(ccs.Armature.RenderCmd, proto);
     proto.constructor = ccs.Armature.WebGLRenderCmd;
 
     proto.rendering = function (ctx, dontChangeMatrix) {

--- a/extensions/cocostudio/armature/CCBone.js
+++ b/extensions/cocostudio/armature/CCBone.js
@@ -695,7 +695,7 @@ ccs.Bone.RenderCmd = {
     };
 
     var proto = ccs.Bone.CanvasRenderCmd.prototype = Object.create(cc.Node.CanvasRenderCmd.prototype);
-    cc.inject(ccs.Bone.RenderCmd, proto);
+    cc.js.mixin(ccs.Bone.RenderCmd, proto);
     proto.constructor = ccs.Bone.CanvasRenderCmd;
 })();
 
@@ -708,6 +708,6 @@ ccs.Bone.RenderCmd = {
     };
 
     var proto = ccs.Bone.WebGLRenderCmd.prototype = Object.create(cc.Node.WebGLRenderCmd.prototype);
-    cc.inject(ccs.Bone.RenderCmd, proto);
+    cc.js.mixin(ccs.Bone.RenderCmd, proto);
     proto.constructor = ccs.Bone.WebGLRenderCmd;
 })();

--- a/extensions/cocostudio/armature/display/CCSkinCanvasRenderCmd.js
+++ b/extensions/cocostudio/armature/display/CCSkinCanvasRenderCmd.js
@@ -53,6 +53,6 @@
     };
 
     var proto = ccs.Skin.CanvasRenderCmd.prototype = Object.create(cc.Sprite.CanvasRenderCmd.prototype);
-    cc.inject(ccs.Skin.RenderCmd, proto);
+    cc.js.mixin(ccs.Skin.RenderCmd, proto);
     proto.constructor = ccs.Skin.CanvasRenderCmd;
 })();

--- a/extensions/cocostudio/armature/display/CCSkinWebGLRenderCmd.js
+++ b/extensions/cocostudio/armature/display/CCSkinWebGLRenderCmd.js
@@ -29,7 +29,7 @@
     };
 
     var proto = ccs.Skin.WebGLRenderCmd.prototype = Object.create(cc.Sprite.WebGLRenderCmd.prototype);
-    cc.inject(ccs.Skin.RenderCmd, proto);
+    cc.js.mixin(ccs.Skin.RenderCmd, proto);
     proto.constructor = ccs.Skin.WebGLRenderCmd;
 
     proto.updateTransform = function(){

--- a/gulp/browserify-entry.js
+++ b/gulp/browserify-entry.js
@@ -1,4 +1,2 @@
 require('../index');
-if (!CC_TEST) {
-    require('../../../builtin/fire-assets/asset');
-}
+//require('../../../builtin/fire-assets/asset');

--- a/gulp/browserify-entry.js
+++ b/gulp/browserify-entry.js
@@ -1,0 +1,4 @@
+require('../index');
+if (!CC_TEST) {
+    require('../../../builtin/fire-assets/asset');
+}

--- a/gulp/tasks/build.js
+++ b/gulp/tasks/build.js
@@ -1,0 +1,171 @@
+var Path = require('path');
+
+var gulp = require('gulp');
+var mirror = require('gulp-mirror');
+var uglify = require('gulp-uglify');
+var rename = require('gulp-rename');
+var sourcemaps = require('gulp-sourcemaps');
+var es = require('event-stream');
+
+var browserify = require('browserify');
+var source = require('vinyl-source-stream');
+var buffer = require('vinyl-buffer');
+var handleErrors = require('../util/handleErrors');
+
+function getUglifyOptions (minify, global_defs) {
+    if (minify) {
+        return {
+            compress: {
+                global_defs: global_defs
+            }
+        };
+    }
+    else {
+        // http://lisperator.net/uglifyjs/compress
+        var compress = {
+            global_defs: global_defs,
+            sequences: false,  // join consecutive statements with the “comma operator”
+            properties: false,  // optimize property access: a["foo"] → a.foo
+            //dead_code: true,  // discard unreachable code
+            drop_debugger: false,  // discard “debugger” statements
+            unsafe: false, // some unsafe optimizations (see below)
+            conditionals: false,  // optimize if-s and conditional expressions
+            comparisons: false,  // optimize comparisons
+            //evaluate: true,  // evaluate constant expressions
+            booleans: false,  // optimize boolean expressions
+            loops: false,  // optimize loops
+            unused: false,  // drop unused variables/functions
+            hoist_funs: false,  // hoist function declarations
+            hoist_vars: false, // hoist variable declarations
+            if_return: false,  // optimize if-s followed by return/continue
+            join_vars: false,  // join var declarations
+            cascade: false,  // try to cascade `right` into `left` in sequences
+            side_effects: false  // drop side-effect-free statements
+            //warnings: true  // warn about potentially dangerous optimizations/code
+        };
+        // http://lisperator.net/uglifyjs/codegen
+        return {
+            mangle: false,
+            preserveComments: 'all',
+            output: {
+                beautify: true,
+                bracketize: true
+            },
+            compress: compress
+        };
+    }
+}
+
+function rebundle(bundler) {
+    var bundle = bundler.bundle()
+        .on('error', handleErrors.handler)
+        .pipe(handleErrors())
+        .pipe(source(paths.outFile))
+        .pipe(buffer());
+
+    var dev = sourcemaps.init({loadMaps: true})
+        .pipe(uglify(getUglifyOptions(false, {
+            CC_EDITOR: false,
+            CC_DEV: true,
+            CC_TEST: false
+        })))
+        .pipe(sourcemaps.write('./', {sourceRoot: './', addComment: true}))
+        .pipe(gulp.dest(paths.outDir));
+
+    var min = rename({ suffix: '.min' });
+    min.pipe(sourcemaps.init({loadMaps: true}))
+        .pipe(uglify(getUglifyOptions(true, {
+            CC_EDITOR: false,
+            CC_DEV: false,
+            CC_TEST: false
+        })))
+        .pipe(sourcemaps.write('./', {sourceRoot: './', addComment: true}))
+        .pipe(gulp.dest(paths.outDir));
+
+    return bundle.pipe(mirror(dev, min));
+}
+
+function rebundle_test(bundler) {
+
+    var PreProcess = false;
+    var TestEditorExtends = true;   // if PreProcess
+    var SourceMap = false;          // if PreProcess
+
+    var bundle = bundler.bundle()
+        .on('error', handleErrors.handler)
+        .pipe(handleErrors())
+        .pipe(source(paths.outFile))
+        .pipe(buffer())
+        .pipe(rename({ suffix: '.test' }));
+
+    if (PreProcess) {
+        if (SourceMap) {
+            bundle = bundle.pipe(sourcemaps.init({loadMaps: true}));
+        }
+        bundle = bundle.pipe(uglify(getUglifyOptions(false, {
+                CC_EDITOR: TestEditorExtends,
+                CC_DEV: TestEditorExtends || true,
+                CC_TEST: true
+            })));
+        if (SourceMap) {
+            bundle = bundle.pipe(sourcemaps.write('./', {sourceRoot: './', addComment: true}));
+        }
+    }
+    bundle = bundle.pipe(gulp.dest(paths.outDir));
+
+    return bundle;
+}
+
+function createBundler() {
+    var options = {
+        debug: true,
+        detectGlobals: false,    // dont insert `process`, `global`, `__filename`, and `__dirname`
+        bundleExternal: false    // dont bundle external modules
+        //standalone: 'engine-framework',
+        //basedir: tempScriptDir
+    };
+    // https://github.com/substack/node-browserify#methods
+    var bundler = new browserify(paths.jsEntry, options);
+    return bundler;
+}
+
+function modularity () {
+    if (typeof exports !== 'undefined') {
+        if (typeof module !== 'undefined' && module.exports) {
+            exports = module.exports = cc;
+        }
+        exports.cc = cc;
+    }
+    else if (typeof define !== 'undefined' && define.amd) {
+        define(cc);
+    }
+    else {
+        var root = typeof global !== 'undefined' ? global : window;
+        root.cc = cc;
+    }
+}
+
+gulp.task('build-modular-cocos2d', ['clean'], function () {
+    var header = new Buffer('(function () {\n');
+    var footer = new Buffer('\n(' + modularity + ')();\n' +
+                            '}).call(window);\n');
+
+    function wrap (header, footer) {
+        return es.through(function (file) {
+            file.contents = Buffer.concat([header, file.contents, footer]);
+            this.emit('data', file);
+        });
+    }
+    gulp.src(paths.originCocos2d)
+        .pipe(wrap(header, footer))
+        .pipe(rename(Path.basename(paths.modularCocos2d)))
+        .pipe(gulp.dest(Path.dirname(paths.modularCocos2d)));
+});
+
+gulp.task('build', ['build-modular-cocos2d', 'clean'], function () {
+    return rebundle(createBundler());
+});
+
+gulp.task('build-test', ['build-modular-cocos2d'], function () {
+    return rebundle_test(createBundler());
+});

--- a/gulp/tasks/build.js
+++ b/gulp/tasks/build.js
@@ -129,26 +129,26 @@ function createBundler() {
     return bundler;
 }
 
-function modularity () {
-    if (typeof exports !== 'undefined') {
-        if (typeof module !== 'undefined' && module.exports) {
-            exports = module.exports = cc;
-        }
-        exports.cc = cc;
-    }
-    else if (typeof define !== 'undefined' && define.amd) {
-        define(cc);
-    }
-    else {
-        var root = typeof global !== 'undefined' ? global : window;
-        root.cc = cc;
-    }
-}
+//function modularity () {
+//    if (typeof exports !== 'undefined') {
+//        if (typeof module !== 'undefined' && module.exports) {
+//            exports = module.exports = cc;
+//        }
+//        exports.cc = cc;
+//    }
+//    else if (typeof define !== 'undefined' && define.amd) {
+//        define(cc);
+//    }
+//    else {
+//        var root = typeof global !== 'undefined' ? global : window;
+//        root.cc = cc;
+//    }
+//}
 
 gulp.task('build-modular-cocos2d', ['clean'], function () {
-    var header = new Buffer('(function () {\n');
-    var footer = new Buffer('\n(' + modularity + ')();\n' +
-                            '}).call(window);\n');
+    var header = new Buffer('(function (cc) {\n');
+    var footer = new Buffer(/*'\n(' + modularity + ')();\n' +*/
+                            '\n}).call(window, cc);\n');
 
     function wrap (header, footer) {
         return es.through(function (file) {

--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -1,0 +1,7 @@
+var Path = require('path');
+var gulp = require('gulp');
+var del = require('del');
+
+gulp.task('clean', function (done) {
+    del(Path.join(paths.outDir, '**/*'), done);
+});

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -1,0 +1,29 @@
+var gulp = require('gulp');
+var fb = require('gulp-fb');
+
+var TimeOutInSeconds = 5;
+
+gulp.task('unit-runner', function() {
+    var js = paths.test.src;
+    var dest = paths.outDir;
+    return gulp.src(js, { read: false, base: './' })
+        .pipe(fb.toFileList())
+        .pipe(fb.generateRunner(paths.test.runner, dest, 'Cocos Test Suite', paths.test.lib))
+        .pipe(gulp.dest(dest));
+});
+
+function test () {
+    var qunit;
+    try {
+        qunit = require('gulp-qunit');
+    }
+    catch (e) {
+        console.error('Please run "npm install gulp-qunit" before running "gulp test".');
+        throw e;
+    }
+    return gulp.src('bin/qunit-runner.html', { read: false })
+        .pipe(qunit({ timeout: TimeOutInSeconds }));
+}
+
+gulp.task('test', ['build-test', 'unit-runner'], test);
+gulp.task('rerun-test', test);

--- a/gulp/util/handleErrors.js
+++ b/gulp/util/handleErrors.js
@@ -1,0 +1,27 @@
+// https://github.com/GoodBoyDigital/pixi.js/blob/c984191777001580b3a81f41cfe354b58d99757f/gulp/util/handleErrors.js
+var gutil = require('gulp-util'),
+    plumber = require('gulp-plumber'),
+    ERROR = gutil.colors.red('[ERROR]');
+
+function errorHandler(err) {
+    var msg = err.toString();
+
+    if (msg === '[object Object]') {
+        msg = err;
+    }
+
+    gutil.log(ERROR, err);
+
+    if (err.stack) {
+        gutil.log(ERROR, err.stack);
+    }
+
+    // Keep gulp from hanging on this task
+    this.emit('end');
+}
+
+module.exports = function () {
+    return plumber(errorHandler);
+};
+
+module.exports.handler = errorHandler;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,30 @@
+﻿var gulp = require('gulp');
+var requireDir = require('require-dir');
+
+// specify game project paths for tasks.
+global.paths = {
+    src: './src',
+    jsEntry: './gulp/browserify-entry',
+    outDir: './bin',
+    outFile: 'cocos2d.js',
+
+    test: {
+        src: 'qunit/unit/**/*.js',
+        runner: 'qunit/lib/qunit-runner.html',
+        lib: [
+            'editor/static/cc-config.js',
+            'bin/cocos2d.test.js',
+        ]
+    },
+
+    get scripts() { return this.src + '/**/*.js'; },
+
+    originCocos2d: './lib/cocos2d-js-v3.9-min.js',
+    modularCocos2d: './bin/modular-cocos2d.js',
+};
+
+// require all tasks in gulp/tasks, including sub-folders
+requireDir('./gulp/tasks', { recurse: true });
+
+// default task
+gulp.task('default', ['build']);

--- a/index.js
+++ b/index.js
@@ -1,0 +1,12 @@
+
+// The CommonJS index file which requires the new modules comes from fireball
+
+//require('./polyfill');
+
+// origin codes compiled by closure
+var cc = require('./bin/modular-cocos2d');
+
+var root = typeof global !== 'undefined' ? global : window;
+root.cc = cc;
+
+require('./cocos2d/core/platform/JS');

--- a/index.js
+++ b/index.js
@@ -1,12 +1,58 @@
+/****************************************************************************
+ Copyright (c) 2008-2010 Ricardo Quesada
+ Copyright (c) 2011-2012 cocos2d-x.org
+ Copyright (c) 2013-2014 Chukong Technologies Inc.
 
-// The CommonJS index file which requires the new modules comes from fireball
+ http://www.cocos2d-x.org
 
-//require('./polyfill');
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
 
-// origin codes compiled by closure
-var cc = require('./bin/modular-cocos2d');
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
+require('./polyfill');
+
+// define cc
+
+var getWrapper;
 var root = typeof global !== 'undefined' ? global : window;
+
+// `cc(node)` takes a runtime node and return its corresponding cc.Runtime.NodeWrapper instance.
+var cc = function (node) {
+    return getWrapper(node);
+};
 root.cc = cc;
 
-require('./cocos2d/core/platform/JS');
+cc._setWrapperGetter = function (getter) {
+    getWrapper = getter;
+};
+
+// origin cocos2d compiled by closure
+require('./bin/modular-cocos2d');
+
+// EXTENDS FOR FIREBALL
+
+require('./cocos2d/core/platform/js');
+
+if (CC_EDITOR) {
+
+    require('./cocos2d/deprecated');
+
+}
+
+
+module.exports = cc;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "cocos2d-html5",
+  "description": "Cocos2d-html5 is a cross-platform 2D game engine written in Javascript, based on Cocos2d-X and licensed under MIT. It incorporates the same high level api as “Cocos2d JS-binding engine” and compatible with Cocos2d-X. It currently supports canvas and WebGL renderering.",
+  "homepage": "http://www.cocos2d-x.org",
+  "authors": [
+    "AUTHORS.txt"
+  ],
+  "license": "MIT",
+  "scripts": {
+    "test": "gulp test"
+  },
+  "dependencies": {
+    "node-uuid": "1.4.2"
+  },
+  "devDependencies": {
+    "browserify": "10.2.3",
+    "del": "1.2.0",
+    "gulp": "3.8.11",
+    "gulp-cached": "1.0.1",
+    "gulp-fb": "0.5.0",
+    "gulp-header": "1.2.2",
+    "gulp-jshint": "1.11.0",
+    "gulp-mirror": "0.4.0",
+    "gulp-plumber": "0.6.6",
+    "gulp-rename": "1.2.2",
+    "gulp-sourcemaps": "1.5.2",
+    "gulp-uglify": "1.2.0",
+    "gulp-util": "3.0.5",
+    "jshint-stylish": "2.0.0",
+    "require-dir": "0.1.0",
+    "vinyl-buffer": "1.0.0",
+    "vinyl-source-stream": "1.0.0"
+  }
+}

--- a/polyfill/bind.js
+++ b/polyfill/bind.js
@@ -1,0 +1,24 @@
+// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind.html
+if (!Function.prototype.bind) {
+    Function.prototype.bind = function (oThis) {
+        //return function () {};
+        if (typeof this !== 'function') {
+            // closest thing possible to the ECMAScript 5
+            // internal IsCallable function
+            throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+        }
+
+        var aArgs = Array.prototype.slice.call(arguments, 1),
+            fToBind = this,
+            fNOP = function () {},
+            fBound = function () {
+                return fToBind.apply(this instanceof fNOP ? this : oThis,
+                    aArgs.concat(Array.prototype.slice.call(arguments)));
+            };
+
+        fNOP.prototype = this.prototype;
+        fBound.prototype = new fNOP();
+
+        return fBound;
+    };
+}

--- a/polyfill/index.js
+++ b/polyfill/index.js
@@ -1,0 +1,2 @@
+require('./bind');
+require('./string');

--- a/polyfill/string.js
+++ b/polyfill/string.js
@@ -1,0 +1,17 @@
+if (!String.prototype.startsWith) {
+    String.prototype.startsWith = function (searchString, position) {
+        position = position || 0;
+        return this.lastIndexOf(searchString, position) === position;
+    };
+}
+
+if (!String.prototype.endsWith) {
+    String.prototype.endsWith = function (searchString, position) {
+        if (typeof position === 'undefined' || position > this.length) {
+            position = this.length;
+        }
+        position -= searchString.length;
+        var lastIndex = this.indexOf(searchString, position);
+        return lastIndex !== -1 && lastIndex === position;
+    };
+}

--- a/qunit/run-helper.sh
+++ b/qunit/run-helper.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sleep 1
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome http://127.0.0.1:8511/bin/qunit-runner.html?notrycatch=true

--- a/qunit/run.sh
+++ b/qunit/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo Run unit tests in Chrome \(sh qunit/run.sh\)
+echo \(You may need to run \"npm install gulp-qunit\" before testing.\)
+echo
+sh qunit/run-helper.sh &
+node qunit/server.js

--- a/qunit/server.js
+++ b/qunit/server.js
@@ -1,0 +1,39 @@
+// init express
+var express = require('express');
+var app = express();
+var cwd = process.cwd();
+var port = 8511;
+
+// create an error with .status.
+function error(status, msg) {
+    var err = new Error(msg);
+    err.status = status;
+    return err;
+}
+
+// routes
+app.get('/', function(req, res) {
+    res.sendFile( cwd + '/qunit/index.html');
+});
+
+// serves all the static files
+app.get(/^(.+)$/, function(req, res) {
+    //console.log('static file request : ' + req.params);
+    //console.log('send: ' + process.cwd() + req.params[0]);
+    res.sendFile( cwd + req.params[0]);
+});
+
+app.use(function(err, req, res, next) {
+    // whatever you want here, feel free to populate
+    // properties on `err` to treat it differently in here.
+    res.status(err.status || 500).send({ error: err.message });
+});
+
+app.use(function(req, res) {
+    res.status(404).send({ error: "404 Error." });
+});
+
+// start the server
+var server = app.listen(port, function() {
+    console.log('Listening on port %d', server.address().port);
+});

--- a/qunit/unit/_polyfill-for-phantom.js
+++ b/qunit/unit/_polyfill-for-phantom.js
@@ -1,0 +1,18 @@
+if (typeof CustomEvent === 'undefined') {
+    CustomEvent = function () {
+
+    }
+}
+
+if (typeof Set == 'undefined') {
+    // very simple polyfill
+    Set = function () {
+        this.values = [];
+    };
+    Set.prototype.has = function (value) {
+        return this.values.indexOf(value) !== -1;
+    };
+    Set.prototype.add = function (value) {
+        this.values.push(value);
+    };
+}

--- a/qunit/unit/test-js.js
+++ b/qunit/unit/test-js.js
@@ -4,7 +4,7 @@ module('getClassName');
 
 test('test', function() {
     var Asset = function () {};
-    cc.JS.setClassName('Asset', Asset);
+    cc.js.setClassName('Asset', Asset);
 
     var MyAsset = (function () {
         var _super = Asset;
@@ -12,25 +12,25 @@ test('test', function() {
         function MyAsset () {
             _super.call(this);
         }
-        cc.JS.extend(MyAsset, _super);
-        cc.JS.setClassName('Foo', MyAsset);
+        cc.js.extend(MyAsset, _super);
+        cc.js.setClassName('Foo', MyAsset);
 
         return MyAsset;
     })();
     var myAsset = new MyAsset();
 
-    equal(cc.JS.getClassName(myAsset), 'Foo', 'can getClassName of user type');
+    equal(cc.js.getClassName(myAsset), 'Foo', 'can getClassName of user type');
 
     delete MyAsset.prototype.__classname__;  // hack, remove class name
-    ok(cc.JS.getClassName(myAsset), 'should fallback to constructor name if classname undefined');
+    ok(cc.js.getClassName(myAsset), 'should fallback to constructor name if classname undefined');
     // (constructor's name may renamed by uglify, so we do not test the value exactly)
 
     var asset = new Asset();
-    notEqual(cc.JS.getClassName(myAsset), cc.JS.getClassName(asset), 'class name should not achieved from its super');
+    notEqual(cc.js.getClassName(myAsset), cc.js.getClassName(asset), 'class name should not achieved from its super');
 
-    cc.JS.unregisterClass(Asset, MyAsset);
+    cc.js.unregisterClass(Asset, MyAsset);
 
-    equal(cc.JS.getClassName(function () {}), '', 'class name should be "" if undefined');
+    equal(cc.js.getClassName(function () {}), '', 'class name should be "" if undefined');
 });
 
 // jshint ignore: end

--- a/qunit/unit/test-js.js
+++ b/qunit/unit/test-js.js
@@ -1,0 +1,36 @@
+﻿// jshint ignore: start
+
+module('getClassName');
+
+test('test', function() {
+    var Asset = function () {};
+    cc.JS.setClassName('Asset', Asset);
+
+    var MyAsset = (function () {
+        var _super = Asset;
+
+        function MyAsset () {
+            _super.call(this);
+        }
+        cc.JS.extend(MyAsset, _super);
+        cc.JS.setClassName('Foo', MyAsset);
+
+        return MyAsset;
+    })();
+    var myAsset = new MyAsset();
+
+    equal(cc.JS.getClassName(myAsset), 'Foo', 'can getClassName of user type');
+
+    delete MyAsset.prototype.__classname__;  // hack, remove class name
+    ok(cc.JS.getClassName(myAsset), 'should fallback to constructor name if classname undefined');
+    // (constructor's name may renamed by uglify, so we do not test the value exactly)
+
+    var asset = new Asset();
+    notEqual(cc.JS.getClassName(myAsset), cc.JS.getClassName(asset), 'class name should not achieved from its super');
+
+    cc.JS.unregisterClass(Asset, MyAsset);
+
+    equal(cc.JS.getClassName(function () {}), '', 'class name should be "" if undefined');
+});
+
+// jshint ignore: end


### PR DESCRIPTION
这个 PR 包含了整合工作流的几方面内容：
- 在 `gulp build` 时将原先用 closure compiler 编译出来的 js 文件封装成一个 node 模块，这个模块就能和 fireball 原有的模块 browserify 到一起，并且能相互调用。
- 加入 CC_EDITOR, CC_DEV, CC_TEST 三个宏，编译到最终版本的预处理时会用到。
- 加入 qunit 单元测试 (gulp test)

另外在 cocos 中新增
- cc.info，作用同 console.info
- 加入 js 模块，其中包含一些 javascript 相关的辅助方法，还实现了用于序列化的类型注册/查找

相关 issue: https://github.com/fireball-x/fireball/issues/325
