### PR TITLE
set canvas size should not change design resolution size

### DIFF
--- a/cocos2d/core/platform/CCEGLView.js
+++ b/cocos2d/core/platform/CCEGLView.js
@@ -485,7 +485,8 @@ cc.EGLView = cc._Class.extend(/** @lends cc.view# */{
         container.style.width = width + 'px';
         container.style.height = height + 'px';
 
-        this.setDesignResolutionSize(width, height, this.getResolutionPolicy());
+        // make canvas size works
+        this.setDesignResolutionSize(this._designResolutionSize.width, this._designResolutionSize.height, this.getResolutionPolicy());
     },
 
     /**
@@ -560,7 +561,7 @@ cc.EGLView = cc._Class.extend(/** @lends cc.view# */{
      * @return {cc.Vec2}
      */
     getVisibleOriginInPixel: function () {
-        return cc.p(this._visibleRect.x * this._scaleX, 
+        return cc.p(this._visibleRect.x * this._scaleX,
                     this._visibleRect.y * this._scaleY);
     },
 


### PR DESCRIPTION
cc.view.setCanvasSize 这里面不应该将 resolution size 也改变为和canvas size 大小一样
这里需要重新设置一下 resolution size 是为了让 canvas size 的改变生效   

将 resolution size 也改变为和canvas size 大小一样 是编辑器的需求，用户调用这个接口一般是为了改变canvas大小，但是游戏的resolution不应该改变，编辑器应该自行去设置 resolution size 为 canvas size大小
