### PR TITLE
add size provider to sync the content size

### DIFF
--- a/cocos2d/core/components/CCComponentInSG.js
+++ b/cocos2d/core/components/CCComponentInSG.js
@@ -4,13 +4,16 @@ var SceneGraphHelper = require('../utils/scene-graph-helper');
  * Component in scene graph.
  * This is the base class for components which will attach a node to the cocos2d scene graph.
  *
+ * You should override:
+ * - _createSgNode
+ *
  * @class _ComponentInSG
  * @extends Component
  */
 var ComponentInSG = cc.Class({
     extends: require('./CCComponent'),
 
-    editor: {
+    editor: CC_EDITOR && {
         executeInEditMode: true
     },
 
@@ -21,6 +24,9 @@ var ComponentInSG = cc.Class({
     onLoad: function () {
         var sgNode = this._createSgNode();
         this._appendSgNode(sgNode);
+        if ( !this.node._sizeProvider ) {
+            this.node._sizeProvider = sgNode;
+        }
     },
     onEnable: function () {
         if (this._sgNode) {
@@ -32,7 +38,24 @@ var ComponentInSG = cc.Class({
             this._sgNode.visible = false;
         }
     },
-    onDestroy: SceneGraphHelper.removeSgNode,
+    onDestroy: function () {
+        if ( this.node._sizeProvider === this._sgNode ) {
+            this.node._sizeProvider = null;
+        }
+        this._removeSgNode();
+    },
+
+    /**
+     * Create and returns your new scene graph node (SGNode) to append to scene graph.
+     * You should call the setContentSize of the SGNode if its size should be the same with the node's.
+     *
+     * @method _createSgNode
+     * @return {cc.Node}
+     * @private
+     */
+    _createSgNode: null,
+
+    _removeSgNode: SceneGraphHelper.removeSgNode,
 
     _appendSgNode: function (sgNode) {
         var node = this.node;
@@ -43,8 +66,6 @@ var ComponentInSG = cc.Class({
         if ( !node._cascadeOpacityEnabled ) {
             sgNode.setOpacity(node._opacity);
         }
-
-        sgNode.setContentSize(node._contentSize);
 
         sgNode.setAnchorPoint(node._anchorPoint);
         sgNode.ignoreAnchorPointForPosition(node._ignoreAnchorPointForPosition);

--- a/cocos2d/core/components/CCSpriteRenderer.js
+++ b/cocos2d/core/components/CCSpriteRenderer.js
@@ -404,7 +404,6 @@ var SpriteRenderer = cc.Class({
 
     _createSgNode: function () {
         var sprite = new cc.Sprite();
-        sprite.setAnchorPoint(0, 1);
 
         if (this._texture) {
             sprite.texture = this._texture;

--- a/cocos2d/core/utils/base-node.js
+++ b/cocos2d/core/utils/base-node.js
@@ -357,7 +357,16 @@ var BaseNode = cc.Class(/** @lends cc.ENode# */{
          * @type {Number}
          */
         width: {
-            get: SGProto._getWidth,
+            get: function () {
+                if (this._sizeProvider) {
+                    var w = this._sizeProvider._getWidth();
+                    this._contentSize.width = w;
+                    return w;
+                }
+                else {
+                    return this._contentSize.width;
+                }
+            },
             set: function (value) {
                 this._contentSize.width = value;
                 this._onSizeChanged();
@@ -370,7 +379,16 @@ var BaseNode = cc.Class(/** @lends cc.ENode# */{
          * @type {Number}
          */
         height: {
-            get: SGProto._getHeight,
+            get: function () {
+                if (this._sizeProvider) {
+                    var h = this._sizeProvider._getHeight();
+                    this._contentSize.height = h;
+                    return h;
+                }
+                else {
+                    return this._contentSize.height;
+                }
+            },
             set: function (value) {
                 this._contentSize.height = value;
                 this._onSizeChanged();
@@ -497,6 +515,15 @@ var BaseNode = cc.Class(/** @lends cc.ENode# */{
         }
 
         this._dirtyFlags = DirtyFlags.ALL;
+
+        /**
+         * Current active scene graph node which provides content size.
+         *
+         * @property _sizeProvider
+         * @type {cc.Node}
+         * @private
+         */
+        this._sizeProvider = null;
     },
 
     // ABSTRACT INTERFACES
@@ -690,7 +717,16 @@ var BaseNode = cc.Class(/** @lends cc.ENode# */{
      * @method getContentSize
      * @return {Size} The untransformed size of the node.
      */
-    getContentSize: SGProto.getContentSize,
+    getContentSize: function () {
+        if (this._sizeProvider) {
+            var size = this._sizeProvider.getContentSize();
+            this._contentSize = size;
+            return size;
+        }
+        else {
+            return cc.size(this._contentSize);
+        }
+    },
 
     /**
      * <p>
@@ -1169,17 +1205,13 @@ var BaseNode = cc.Class(/** @lends cc.ENode# */{
         return false;
     },
 
-    // The deserializer for sgNode which will be called before creating components
+    // The deserializer for sgNode which will be called before components onLoad
     _onBatchCreated: function () {
         var sgNode = this._sgNode;
         sgNode.setOpacity(this._opacity);
         sgNode.setColor(this._color);
         sgNode.setCascadeOpacityEnabled(this._cascadeOpacityEnabled);
         sgNode.setCascadeColorEnabled(this._cascadeColorEnabled);
-        /* DISABLE: unused in SGNode
-        sgNode.setAnchorPoint(this._anchorPoint);
-        sgNode.setContentSize(this._contentSize);
-        */
         sgNode.setRotationX(this._rotationX);
         sgNode.setRotationY(this._rotationY);
         sgNode.setScale(this._scaleX, this._scaleY);

--- a/test/qunit/unit/test-asset-library.js
+++ b/test/qunit/unit/test-asset-library.js
@@ -59,7 +59,7 @@
         var timerId = setTimeout(function () {
             ok(false, 'time out!');
             start();
-        }, 100);
+        }, 200);
     });
 
     asyncTest('load asset with depends asset recursively if no cache', function () {
@@ -78,7 +78,7 @@
         var timerId = setTimeout(function () {
             ok(false, 'time out!');
             start();
-        }, 100);
+        }, 200);
     });
 
 })();


### PR DESCRIPTION
for fireball-x/fireball#507,
在 cc.ENode 上加了一个指向 renderer 的引用，用来实时获取正确的 content size
这个方案是一个临时方案，之后实现脏标记后，还是需要使用来自 renderer 的回调。
