### PR TITLE
returns the incoming callback in EventTarget.on

### DIFF
--- a/cocos2d/core/event/event-target.js
+++ b/cocos2d/core/event/event-target.js
@@ -139,6 +139,7 @@ JS.mixin(EventTarget.prototype, {
      *                              from being invoked when the event's eventPhase attribute value is BUBBLING_PHASE.
      *                              When false, callback will NOT be invoked when event's eventPhase attribute value is CAPTURING_PHASE.
      *                              Either way, callback will be invoked when event's eventPhase attribute value is AT_TARGET.
+     * @return {Function} - Just returns the incoming callback so you can save the anonymous function easier.
      */
     on: function (type, callback, target, useCapture) {
         // Accept also patameters like: (type, callback, useCapture)
@@ -164,6 +165,7 @@ JS.mixin(EventTarget.prototype, {
             if (target && target.__eventTargets)
                 target.__eventTargets.push(this);
         }
+        return callback;
     },
 
     /**


### PR DESCRIPTION
用户一般会先写：

``` js
target.on('load', function () {
    // ...
});
```

然后他想起来还要写反注册，就要移动 function

``` js
var loadingCB = function () {
    // ...
};
target.on('load', loadingCB);
// ...
target.off('load', loadingCB);
```

现在可以直接把变量定义在前面，思路更加连贯

``` js
var loadingCB = target.on('load', function () {
    // ...
});
// ...
target.off('load', loadingCB);
```
